### PR TITLE
Save path based on platform

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -414,7 +414,7 @@ void MainWindow::readSettings()
 		edict[vName] = config.value(vName, "file0");
 		config.setValue(vName, edict.value(vName));
 		vName = "directory";
-		edict[vName] = config.value(vName, QDir::homePath() + "/AppData/Local/UNDERTALE/");
+		edict[vName] = config.value(vName, UNDERTALE_PATH);
 		config.setValue(vName, edict.value(vName));
 		vName = "loadfile";
 		edict[vName] = config.value(vName, false);

--- a/mainwindow.h
+++ b/mainwindow.h
@@ -2,6 +2,14 @@
 #define MAINWINDOW_H
 #define TITLELABEL windowFilePath() + "[*]" + " - " + QApplication::applicationName() + " (v" + QApplication::applicationVersion() + ")"
 
+#if defined(__linux__)
+#  define UNDERTALE_PATH (QDir::homePath() + "/.config/UNDERTALE/")
+#elif defined(__macosx__)
+#  define UNDERTALE_PATH (QDir::homePath() + "/Library/Application Support/com.tobyfox.undertale/")
+#else
+#  define UNDERTALE_PATH (QDir::homePath() + "/AppData/Local/UNDERTALE/")
+#endif
+
 // I like having my includes in a single place
 #include "configdialog.h"
 


### PR DESCRIPTION
This is a very minor tweak. Your save editor is awesome, by the way. I made a patch that uses #define to allow other platforms' compilers to use proper locations for finding save files. I believe the OSX path is correct; I don't own a mac, but with qt on mac theoretically a version could be built from source so they won't be left out of the party. As for linux...there's no official version _yet_. I posted a hackish method on /r/underminers to do so (still hoping for an official release.)

I can't verify if the mac code works (it should), but the linux bit works as intended and there's no change to the windows bit.
