### PR TITLE
Fix corrupted data error when loading files

### DIFF
--- a/web/core/common.js
+++ b/web/core/common.js
@@ -179,7 +179,7 @@ const openFile = (input) => {
 		const text = data.split(/[\r\n]+/);
 
 		for (let i = 1; i < SAVE_LEN; ++i) {
-			SaveData[i] = text[i - 1];
+			SaveData[i] = text[i - 1].trim();
 		}
 		SaveData[SAVE_LEN] = String(parseFloat(text[SAVE_LEN - 1]).toExponential());
 

--- a/web/helpers.js
+++ b/web/helpers.js
@@ -1,7 +1,7 @@
 // noinspection SpellCheckingInspection
 
 // ##### Credits #####
-const Project_Credits = "chaoskagami,Araraura,hax4dazy,EpicSpieler";
+const Project_Credits = "chaoskagami,Araraura,hax4dazy,EpicSpieler,donlon";
 const Project_Author = "Cofeiini";
 
 // ##### Project link #####


### PR DESCRIPTION
Hi,
Thank you for the awesome tool!
I found that when loading save files from my computer (created by latest version of the game downloaded from Steam), the webpage generates 'corrupted data found' errors, like

```
Corrupted data found at HP display (ID 540). Got 0 , but expected 0,1,2,3,4. Using 0 as fallback.
Corrupted data found at Stage of the final fight (ID 532). Got 3 , but expected 0,1,2,3. Using 0 as fallback.
Corrupted data found at Got the key to sans's room (ID 528). Got 0 , but expected 0,1,2,3. Using 0 as fallback.
```

It's caused by an extra tailing space in almost every line of the save file (not sure why the game adds it). Trimming loaded lines may help.