### PR TITLE
Fix unrecognized option for 'Conversation with Muffet'

### DIFF
--- a/web/core/tools.js
+++ b/web/core/tools.js
@@ -745,6 +745,8 @@ export class ComboEditor extends EditorBase {
 				this.indexes[4] = 4;
 				this.addItem(`"I heard..."`);
 				this.indexes[5] = 5;
+				this.addItem("Finished battle with Muffet");
+				this.indexes[6] = 6;
 				break;
 			}
 			case 429: {


### PR DESCRIPTION
Hi,

It seems that the tool doesn't recognize option '6' for 'Conversation with Muffet'. I believe it means 'Finished battle with Muffet' as it's changed from 5 to 6 after the battle with Muffet is finished (both spared or killed).